### PR TITLE
Throw an exception if NODE_ENV is not set when running webpack

### DIFF
--- a/lib/install/config/webpack/configuration.js
+++ b/lib/install/config/webpack/configuration.js
@@ -22,6 +22,10 @@ function formatPublicPath(host = '', path = '') {
   return `${formattedHost}/${formattedPath}/`
 }
 
+if (typeof env.NODE_ENV == 'undefined') {
+  throw "Cannot start webpack: ENV[NODE_ENV] not set." 
+}
+
 const output = {
   path: resolve('public', settings.public_output_path),
   publicPath: formatPublicPath(env.ASSET_HOST, settings.public_output_path)


### PR DESCRIPTION
On a brand new install, if NODE_ENV is not already set, then 
running `bin/webpack` will fail with an obscure error message:

```
  path: resolve('public', settings.public_output_path),
                                  ^

TypeError: Cannot read property 'public_output_path' of undefined
    at Object.<anonymous> (.../config/webpack/configuration.js:26:35)
```

Since someone will never be able to run webpack without NODE_ENV set,
it makes sense to give the developer a message to help them debug.